### PR TITLE
Implement difficulty initialization and separate config/trainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+data

--- a/py_irt/cli.py
+++ b/py_irt/cli.py
@@ -1,9 +1,11 @@
+from typing import Optional, List
 from py_irt.io import write_json
 import typer
 import time
 from pathlib import Path
 from rich.console import Console
 from py_irt.training import IrtModelTrainer
+from py_irt.config import IrtConfig
 
 
 console = Console()
@@ -12,16 +14,22 @@ app = typer.Typer()
 
 @app.command()
 def train(
-    model_type: str, data_path: str, output_dir: str, epochs: int = 2000, device: str = "cpu"
+    model_type: str,
+    data_path: str,
+    output_dir: str,
+    epochs: int = 2000,
+    device: str = "cpu",
+    initializers: Optional[List[str]] = None,
 ):
     console.log(f"model_type: {model_type} data_path: {model_type}")
     start_time = time.time()
-    trainer = IrtModelTrainer(model_type=model_type, data_path=data_path)
+    config = IrtConfig(model_type=model_type, epochs=epochs, initializers=initializers)
+    trainer = IrtModelTrainer(config=config, data_path=data_path)
     output_dir = Path(output_dir)
     console.log("Training Model...")
-    trainer.train(iterations=epochs, device=device)
+    trainer.train(device=device)
     trainer.save(output_dir / "parameters.json")
-    write_json(output_dir / "best_parameters.json", trainer._best_params)
+    write_json(output_dir / "best_parameters.json", trainer.best_params)
     end_time = time.time()
     elapsed_time = end_time - start_time
     console.log("Train time:", elapsed_time)

--- a/py_irt/config.py
+++ b/py_irt/config.py
@@ -1,0 +1,9 @@
+from typing import List, Dict, Union, Optional
+from pydantic import BaseModel
+
+
+class IrtConfig(BaseModel):
+    model_type: str
+    epochs: int = 2000
+    priors: str = "hierarchical"
+    initializers: Optional[List[Union[str, Dict]]] = None

--- a/py_irt/dataset.py
+++ b/py_irt/dataset.py
@@ -1,0 +1,92 @@
+from typing import Set, Dict, List
+from pathlib import Path
+from pydantic import BaseModel
+from py_irt.io import read_jsonlines
+
+
+class ItemAccuracy(BaseModel):
+    correct: int = 0
+    total: int = 0
+
+    @property
+    def accuracy(self):
+        return self.correct / max(1, self.total)
+
+
+class Dataset(BaseModel):
+    item_ids: Set[str]
+    subject_ids: Set[str]
+    item_id_to_ix: Dict[str, int]
+    ix_to_item_id: Dict[int, str]
+    subject_id_to_ix: Dict[str, int]
+    ix_to_subject_id: Dict[int, str]
+    # observation_subjects and observation_items refers to indices
+    observation_subjects: List[int]
+    observation_items: List[int]
+    # Actual response value, usually an integer
+    observations: List[float]
+
+    def get_item_accuracies(self) -> Dict[str, ItemAccuracy]:
+        item_accuracies = {}
+        for ix, response in enumerate(self.observations):
+            item_ix = self.observation_items[ix]
+            item_id = self.ix_to_item_id[item_ix]
+            if item_id not in item_accuracies:
+                item_accuracies[item_id] = ItemAccuracy()
+
+            item_accuracies[item_id].correct += response
+            item_accuracies[item_id].total += 1
+
+        return item_accuracies
+
+    @classmethod
+    def from_jsonlines(cls, data_path: Path):
+        """Parse IRT dataset from jsonlines, formatted in the following way:
+        * The dataset is in jsonlines format, each line representing the responses of a subject
+        * Each row looks like this:
+        {"subject_id": "<subject_id>", "responses": {"<item_id>": <response>}}
+        * Where <subject_id> is a string, <item_id> is a string, and <response> is a number (usually integer)
+        """
+        item_ids = set()
+        subject_ids = set()
+        item_id_to_ix = {}
+        ix_to_item_id = {}
+        subject_id_to_ix = {}
+        ix_to_subject_id = {}
+        input_data = read_jsonlines(data_path)
+        for line in input_data:
+            subject_id = line["subject_id"]
+            subject_ids.add(subject_id)
+            responses = line["responses"]
+            for item_id in responses.keys():
+                item_ids.add(item_id)
+
+        for idx, item_id in enumerate(item_ids):
+            item_id_to_ix[item_id] = idx
+            ix_to_item_id[idx] = item_id
+
+        for idx, subject_id in enumerate(subject_ids):
+            subject_id_to_ix[subject_id] = idx
+            ix_to_subject_id[idx] = subject_id
+
+        observation_subjects = []
+        observation_items = []
+        observations = []
+        for idx, line in enumerate(input_data):
+            subject_id = line["subject_id"]
+            for item_id, response in line["responses"].items():
+                observations.append(response)
+                observation_subjects.append(subject_id_to_ix[subject_id])
+                observation_items.append(item_id_to_ix[item_id])
+
+        return cls(
+            item_ids=item_ids,
+            subject_ids=subject_ids,
+            item_id_to_ix=item_id_to_ix,
+            ix_to_item_id=ix_to_item_id,
+            subject_id_to_ix=subject_id_to_ix,
+            ix_to_subject_id=ix_to_subject_id,
+            observation_subjects=observation_subjects,
+            observation_items=observation_items,
+            observations=observations,
+        )

--- a/py_irt/initializers.py
+++ b/py_irt/initializers.py
@@ -1,0 +1,73 @@
+"""
+A set of initializers to modify how IRT models are initialized.
+
+For example, the expression disc * (skill - diff) permits two equivalent
+solutions, one where disc/skill/diff are "normal", and another one where the
+sign on each is flipped. Initializing difficulty helps push towards the intuitive
+solution.
+"""
+import abc
+import torch
+import pyro
+from rich.console import Console
+from py_irt.dataset import Dataset, ItemAccuracy
+
+
+console = Console()
+INITIALIZERS = {}
+
+
+def register(name: str):
+    def decorator(class_):
+        INITIALIZERS[name] = class_
+        return class_
+
+    return decorator
+
+
+class IrtInitializer(abc.ABC):
+    def __init__(self, dataset: Dataset):
+        self._dataset = dataset
+
+    def initialize(self) -> None:
+        pass
+
+
+@register("difficulty_sign")
+class DifficultySignInitializer(IrtInitializer):
+    def __init__(self, dataset: Dataset, magnitude: float = 3.0, n_to_init: int = 4):
+        super().__init__(dataset)
+        self._magnitude = magnitude
+        self._n_to_init = n_to_init
+
+    def initialize(self) -> None:
+        """
+        Initialize the hardest and easiest (by accuracy) n_to_init item difficulties.
+        Set to magnitude.
+        """
+        item_accuracies = {}
+        for item_ix, response in zip(self._dataset.observation_items, self._dataset.observations):
+            if item_ix not in item_accuracies:
+                item_accuracies[item_ix] = ItemAccuracy()
+
+            item_accuracies[item_ix].correct += response
+            item_accuracies[item_ix].total += 1
+
+        sorted_item_accuracies = sorted(
+            list(item_accuracies.items()), key=lambda kv: kv[1].accuracy
+        )
+
+        diff = pyro.param("loc_diff")
+        for item_ix, accuracy in sorted_item_accuracies[: self._n_to_init]:
+            item_id = self._dataset.ix_to_item_id[item_ix]
+            console.log(f"Low Accuracy: {accuracy}, ix={item_ix} id={item_id}")
+            diff.data[item_ix] = torch.tensor(
+                self._magnitude, dtype=diff.data.dtype, device=diff.data.device
+            )
+
+        for item_ix, accuracy in sorted_item_accuracies[-self._n_to_init :]:
+            item_id = self._dataset.ix_to_item_id[item_ix]
+            console.log(f"High Accuracy: {accuracy}, ix={item_ix} id={item_id}")
+            diff.data[item_ix] = torch.tensor(
+                -self._magnitude, dtype=diff.data.dtype, device=diff.data.device
+            )

--- a/tests/test_fourPL.py
+++ b/tests/test_fourPL.py
@@ -1,4 +1,5 @@
 # preliminaries
+from py_irt.config import IrtConfig
 import unittest
 
 # import model for testing
@@ -8,8 +9,9 @@ from py_irt.training import IrtModelTrainer
 
 class TestFourPL(unittest.TestCase):
     def test_training(self):
-        trainer = IrtModelTrainer(model_type="4pl", data_path="test_fixtures/minitest.jsonlines")
-        trainer.train(iterations=100, device="cpu")
+        config = IrtConfig(model_type="4pl", epochs=100)
+        trainer = IrtModelTrainer(config=config, data_path="test_fixtures/minitest.jsonlines")
+        trainer.train(device="cpu")
         trainer.save("/tmp/parameters.json")
 
     def test_priors(self):

--- a/tests/test_initializer.py
+++ b/tests/test_initializer.py
@@ -1,0 +1,24 @@
+from py_irt.initializers import DifficultySignInitializer
+from py_irt.dataset import Dataset
+from py_irt.training import IrtModelTrainer
+from py_irt.config import IrtConfig
+
+
+def test_parsing():
+    config = IrtConfig(model_type="4pl", initializers=[])
+    # This loads the initializer, so is a fine test
+    trainer = IrtModelTrainer(data_path="test_fixtures/minitest.jsonlines", config=config)
+    assert len(trainer._initializers) == 0
+
+    config = IrtConfig(model_type="4pl", initializers=["difficulty_sign"])
+    trainer = IrtModelTrainer(data_path="test_fixtures/minitest.jsonlines", config=config)
+    assert len(trainer._initializers) == 1
+    assert isinstance(trainer._initializers[0], DifficultySignInitializer)
+
+    config = IrtConfig(
+        model_type="4pl", initializers=[{"name": "difficulty_sign", "magnitude": 5.0}]
+    )
+    trainer = IrtModelTrainer(data_path="test_fixtures/minitest.jsonlines", config=config)
+    assert len(trainer._initializers) == 1
+    assert isinstance(trainer._initializers[0], DifficultySignInitializer)
+    assert trainer._initializers[0]._magnitude == 5.0

--- a/tests/test_onePL.py
+++ b/tests/test_onePL.py
@@ -1,4 +1,5 @@
 # preliminaries
+from py_irt.config import IrtConfig
 from py_irt.training import IrtModelTrainer
 import numpy as np
 import pyro
@@ -37,8 +38,9 @@ class TestOnePL(unittest.TestCase):
         self.responses = torch.tensor(responses, dtype=torch.float, device=device)
 
     def test_training(self):
-        trainer = IrtModelTrainer(model_type="1pl", data_path="test_fixtures/minitest.jsonlines")
-        trainer.train(iterations=100, device="cpu")
+        config = IrtConfig(model_type="1pl", epochs=100)
+        trainer = IrtModelTrainer(config=config, data_path="test_fixtures/minitest.jsonlines")
+        trainer.train(device="cpu")
         trainer.save("/tmp/parameters.json")
 
     def test_priors(self):

--- a/tests/test_twoPL.py
+++ b/tests/test_twoPL.py
@@ -1,4 +1,5 @@
 # preliminaries
+from py_irt.config import IrtConfig
 from py_irt.training import IrtModelTrainer
 import numpy as np
 import pyro
@@ -37,8 +38,9 @@ class TestTwoPL(unittest.TestCase):
         self.responses = torch.tensor(responses, dtype=torch.float, device=device)
 
     def test_training(self):
-        trainer = IrtModelTrainer(model_type="2pl", data_path="test_fixtures/minitest.jsonlines")
-        trainer.train(iterations=100, device="cpu")
+        config = IrtConfig(model_type="2pl", epochs=100)
+        trainer = IrtModelTrainer(config=config, data_path="test_fixtures/minitest.jsonlines")
+        trainer.train(device="cpu")
         trainer.save("/tmp/parameters.json")
 
     def test_priors(self):


### PR DESCRIPTION
1. Move out Dataset and related classes to their own file to avoid
   circular imports
2. Factor out configuration from the trainer
3. Implement a mechanism for initializing pyro param values
4. Implement a way to initialize difficulty params to avoid sign
   ambiguity