### PR TITLE
Improved Python ergonomics

### DIFF
--- a/examples/python_demo.ipynb
+++ b/examples/python_demo.ipynb
@@ -1,0 +1,218 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using py-irt in Python Code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first need to import the `Dataset` class and the model we want to use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from py_irt.dataset import Dataset\n",
+    "from py_irt.models import OneParamLog\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dataset can be initialized from a pandas dataframe. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Dataset(item_ids=OrderedSet(['item_1', 'item_2', 'item_3']), subject_ids=OrderedSet(['joe', 'sarah', 'juan', 'julia']), item_id_to_ix={'item_1': 0, 'item_2': 1, 'item_3': 2}, ix_to_item_id={0: 'item_1', 1: 'item_2', 2: 'item_3'}, subject_id_to_ix={'joe': 0, 'sarah': 1, 'juan': 2, 'julia': 3}, ix_to_subject_id={0: 'joe', 1: 'sarah', 2: 'juan', 3: 'julia'}, observation_subjects=[0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3], observation_items=[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2], observations=[0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 0.0], training_example=[True, True, True, True, True, True, True, True, True, True, True, True])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.DataFrame({\n",
+    "    'subject_id': [\"joe\", \"sarah\", \"juan\", \"julia\"],\n",
+    "    'item_1': [0, 1, 1, 1],\n",
+    "    'item_2': [0, 1, 0, 1],\n",
+    "    'item_3': [1, 0, 1, 0],\n",
+    "})\n",
+    "\n",
+    "data = Dataset.from_pandas(df, subject_column=\"subject_id\", item_columns=[\"item_1\", \"item_2\", \"item_3\"])\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As the model trains, it will print out a log of the optimization process. You can inspect this to see if the model converged. If the loss has stopped going down at the end of the training process, that's a good sign. If not, you can go back and add more epochs to the training process or adjust the learning rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">[15:24:00] </span>Vocab size: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span>                                                                          <a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">training.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#92\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">92</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m[15:24:00]\u001b[0m\u001b[2;36m \u001b[0mVocab size: \u001b[3;35mNone\u001b[0m                                                                          \u001b]8;id=755392;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\u001b\\\u001b[2mtraining.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=919855;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#92\u001b\\\u001b[2m92\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>args: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'device'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'cpu'</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'num_items'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'num_subjects'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span><span style=\"font-weight: bold\">}</span>                               <a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">training.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#142\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">142</span></a>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0margs: \u001b[1m{\u001b[0m\u001b[32m'device'\u001b[0m: \u001b[32m'cpu'\u001b[0m, \u001b[32m'num_items'\u001b[0m: \u001b[1;36m3\u001b[0m, \u001b[32m'num_subjects'\u001b[0m: \u001b[1;36m4\u001b[0m\u001b[1m}\u001b[0m                               \u001b]8;id=465996;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\u001b\\\u001b[2mtraining.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=753315;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#142\u001b\\\u001b[2m142\u001b[0m\u001b]8;;\u001b\\\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span>Parsed Model Args: <span style=\"font-weight: bold\">{</span><span style=\"color: #008000; text-decoration-color: #008000\">'device'</span>: <span style=\"color: #008000; text-decoration-color: #008000\">'cpu'</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'num_items'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'num_subjects'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'priors'</span>:        <a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">training.py</span></a><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">:</span><a href=\"file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#155\" target=\"_blank\"><span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">155</span></a>\n",
+       "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">           </span><span style=\"color: #008000; text-decoration-color: #008000\">'vague'</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'dropout'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.5</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'hidden'</span>: <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">100</span>, <span style=\"color: #008000; text-decoration-color: #008000\">'vocab_size'</span>: <span style=\"color: #800080; text-decoration-color: #800080; font-style: italic\">None</span><span style=\"font-weight: bold\">}</span>                              <span style=\"color: #7f7f7f; text-decoration-color: #7f7f7f\">               </span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "\u001b[2;36m          \u001b[0m\u001b[2;36m \u001b[0mParsed Model Args: \u001b[1m{\u001b[0m\u001b[32m'device'\u001b[0m: \u001b[32m'cpu'\u001b[0m, \u001b[32m'num_items'\u001b[0m: \u001b[1;36m3\u001b[0m, \u001b[32m'num_subjects'\u001b[0m: \u001b[1;36m4\u001b[0m, \u001b[32m'priors'\u001b[0m:        \u001b]8;id=369933;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py\u001b\\\u001b[2mtraining.py\u001b[0m\u001b]8;;\u001b\\\u001b[2m:\u001b[0m\u001b]8;id=188857;file:///Users/leoware/Documents/projects/py-irt/py_irt/training.py#155\u001b\\\u001b[2m155\u001b[0m\u001b]8;;\u001b\\\n",
+       "\u001b[2;36m           \u001b[0m\u001b[32m'vague'\u001b[0m, \u001b[32m'dropout'\u001b[0m: \u001b[1;36m0.5\u001b[0m, \u001b[32m'hidden'\u001b[0m: \u001b[1;36m100\u001b[0m, \u001b[32m'vocab_size'\u001b[0m: \u001b[3;35mNone\u001b[0m\u001b[1m}\u001b[0m                              \u001b[2m               \u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cdb007ce91324993a06acebb5aaba9ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Output()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Training Pyro IRT Model for <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">2000</span> epochs\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Training Pyro IRT Model for \u001b[1;36m2000\u001b[0m epochs\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([12]) torch.Size([12])\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
+      ],
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "trainer = OneParamLog.train(data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can access the latent parameters learned by the model as follows. Here, ability refers to the skill level of the subjects, and diff refers to the difficulty of the questions. More complex models will output additional learned parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'ability': [-0.42398425936698914,\n",
+       "  0.40321773290634155,\n",
+       "  -0.19672061502933502,\n",
+       "  0.24712613224983215],\n",
+       " 'diff': [-1.788277268409729, -0.1706286072731018, 0.4681573212146759]}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "trainer.irt_model.export()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/py_irt/models/__init__.py
+++ b/py_irt/models/__init__.py
@@ -1,0 +1,7 @@
+from py_irt.models.abstract_model import IrtModel
+from py_irt.models.amortized_1pl import Amortized1PL
+from py_irt.models.multidim_2pl import Multidim2PL
+from py_irt.models.one_param_logistic import OneParamLog
+from py_irt.models.two_param_logistic import TwoParamLog
+from py_irt.models.three_param_logistic import ThreeParamLog
+from py_irt.models.four_param_logistic import FourParamLog

--- a/py_irt/models/abstract_model.py
+++ b/py_irt/models/abstract_model.py
@@ -24,7 +24,6 @@
 import abc
 from typing import Dict, Any
 
-
 _IRT_REGISTRY = {}
 
 
@@ -77,3 +76,21 @@ class IrtModel(abc.ABC):
     @abc.abstractmethod
     def export(self) -> Dict[str, Any]:
         pass
+
+    @classmethod
+    def train(cls, dataset, **kw):
+        # import here to avoid circular import
+        from py_irt.config import IrtConfig
+        from py_irt.training import IrtModelTrainer
+
+        inv_irt_registry = {v: k for k, v in _IRT_REGISTRY.items()}
+        try:
+            my_name = inv_irt_registry[cls]
+        except KeyError:
+            raise KeyError("model not found in registry")
+
+        config = IrtConfig(model_type=my_name, **kw)
+        trainer = IrtModelTrainer(dataset=dataset, data_path=None, config=config)
+        trainer.train()
+        
+        return trainer

--- a/tests/test_abstract_model.py
+++ b/tests/test_abstract_model.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from py_irt.dataset import Dataset
+from py_irt.models import *
+
+
+def test_train_models():
+    df = pd.DataFrame({
+        'subject_id': ["joe", "sarah", "juan", "julia"],
+        'item_1': [0, 1, 1, 1],
+        'item_2': [0, 1, 0, 1],
+        'item_3': [1, 0, 1, 0],
+    })
+
+    data = Dataset.from_pandas(df, subject_column="subject_id", item_columns=["item_1", "item_2", "item_3"])
+
+    for model in [OneParamLog, TwoParamLog, ThreeParamLog, Multidim2PL]:
+        trainer = model.train(data, epochs=10)
+        trainer.irt_model.export()


### PR DESCRIPTION
I wrote a couple of helper utilities to make it easier to use the code inside other Python code.

Key changes:
- Added a Dataset.from_pandas method
- Added a train method to IrtModel
- Added an example notebook demonstrating how to use the new features
- Tests for my code

I was trying to use this library for a personal project, but I had trouble understanding how to orchestrate the whole IrtModel/IrtTrainer/IrtConfig setup at first. Also, I needed to use data that was in memory rather than in a file for my usecase, which was tricky previously. So, I thought I'd write some methods to get around these issues.

The following code now works:

```python
from py_irt.dataset import Dataset
from py_irt.models import OneParamLog
import pandas as pd

df = pd.DataFrame({
    'subject_id': ["joe", "sarah", "juan", "julia"],
    'item_1': [0, 1, 1, 1],
    'item_2': [0, 1, 0, 1],
    'item_3': [1, 0, 1, 0],
})
dataset = Dataset.from_pandas(df, subject_column="subject_id", item_columns=["item_1", "item_2", "item_3"])

trainer = OneParamLog.train(data)
print(trainer.irt_model.export())
```