### PR TITLE
add link to EACL tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Once you install from PyPI, you can use the following command to fit an IRT
 model on the scored predictions of a dataset. For example, if you were to run py-irt with the 4PL model on the scored predictions of different transformer models on the SQuAD dataset, you'd do this:
 `py-irt train 4pl ~/path/to/dataset/eg/squad.jsonlines /path/to/output/eg/test-4pl/`
 
+Please see the [EACL 2024 IRT4NLP tutorial](https://eacl2024irt.github.io/notebooks/2_IntroToIRT_jupyter.html) which showcases py-irt usage from within Python and not from CLI.
+
 ## FAQ
 
 1. What kind of output should I expect on running the command to train an IRT model?


### PR DESCRIPTION
Hi, thanks for the great repository.

Prior to watching the EACL tutorial, I thought that this package is to be used from command line only (and I tried to write some wrappers around that). The tutorial showed me that there's a much easier way through within Python. I hope this helps others in a similar position to mine.

Let me know if you'd like to have different wording in the README or also include the second tutorial, though I feel like it demonstrates the basic usage less.