### PR TITLE
fix IRT formula in 4PL

### DIFF
--- a/py_irt/models/four_param_logistic.py
+++ b/py_irt/models/four_param_logistic.py
@@ -118,7 +118,7 @@ class FourParamLog(abstract_model.IrtModel):
             disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
-            p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
+            p_star = torch.sigmoid(- disc[items] * (ability[subjects] - diff[items]))
             pyro.sample(
                 "obs",
                 dist.Bernoulli(probs=lambdas[items] * p_star),

--- a/py_irt/models/tutorial_model.py
+++ b/py_irt/models/tutorial_model.py
@@ -122,7 +122,7 @@ class FourParamLog(abstract_model.IrtModel):
             disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
-            p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
+            p_star = torch.sigmoid(- disc[items] * (ability[subjects] - diff[items]))
             pyro.sample(
                 "obs",
                 dist.Bernoulli(probs=p_star),


### PR DESCRIPTION
The optimization formula in 4PL and the tutorial seems to be incorrect, it should be `sigmoid[ - disc * (ability - diff) ]`.

Normally it wouldn't be an issue because either discs/ability/diff would just be flipped, though I believe there are some priors trying to enforce positivity? In addition I wonder how the model still kinda works when the model prediction has the correct formula.