### PR TITLE
Fix 2PL: constrain discrimination to be positive via LogNormal

### DIFF
--- a/py_irt/initializers.py
+++ b/py_irt/initializers.py
@@ -157,12 +157,16 @@ class AnchorItemInitializer(IrtInitializer):
                 # console.log(f"  {item_id} (ix={item_ix}): difficulty_vector={anchor.difficulty_vector}")
             
             # Set discrimination (vector for multidim, scalar for 1D)
+            # Discrimination params are in log-space (LogNormal guide), so store log(value)
             if has_disc:
                 disc_value = anchor.discrimination_vector if is_multidim else anchor.discrimination
                 if disc_value is not None:
                     with torch.no_grad():
                         if isinstance(disc_value, list):
                             disc_value = torch.tensor(disc_value, dtype=loc_disc.dtype, device=loc_disc.device)
+                            disc_value = torch.log(disc_value)
+                        else:
+                            disc_value = torch.log(torch.tensor(float(disc_value), dtype=loc_disc.dtype, device=loc_disc.device))
                         loc_disc[item_ix] = disc_value
                         scale_disc[item_ix] = NEAR_ZERO_SCALE
                     # console.log(f"  {item_id} (ix={item_ix}): discrimination_vector={anchor.discrimination_vector}")

--- a/py_irt/initializers.py
+++ b/py_irt/initializers.py
@@ -157,8 +157,7 @@ class AnchorItemInitializer(IrtInitializer):
                 # console.log(f"  {item_id} (ix={item_ix}): difficulty_vector={anchor.difficulty_vector}")
             
             # Set discrimination (vector for multidim, scalar for 1D)
-            # Discrimination params have constraint=positive, so we must set
-            # unconstrained values (log-space) via the param store directly.
+            # loc_slope/loc_disc is in log-space (LogNormal), so store log(value)
             if has_disc:
                 disc_value = anchor.discrimination_vector if is_multidim else anchor.discrimination
                 if disc_value is not None:
@@ -167,13 +166,6 @@ class AnchorItemInitializer(IrtInitializer):
                             disc_value = torch.tensor(disc_value, dtype=loc_disc.dtype, device=loc_disc.device)
                         else:
                             disc_value = torch.tensor(float(disc_value), dtype=loc_disc.dtype, device=loc_disc.device)
-                        param_store = pyro.get_param_store()
-                        disc_name = "loc_slope" if "loc_slope" in param_store else "loc_disc"
-                        scale_name = "scale_slope" if "scale_slope" in param_store else "scale_disc"
-                        # Set unconstrained loc to log(target) so constrained = exp(log(target)) = target
-                        param_store._params[disc_name].data[item_ix] = disc_value.log()
-                        # Set unconstrained scale to log(NEAR_ZERO_SCALE) for a near-delta distribution
-                        param_store._params[scale_name].data[item_ix] = torch.tensor(
-                            NEAR_ZERO_SCALE, dtype=loc_disc.dtype, device=loc_disc.device
-                        ).log()
+                        loc_disc[item_ix] = disc_value.log()
+                        scale_disc[item_ix] = NEAR_ZERO_SCALE
                     # console.log(f"  {item_id} (ix={item_ix}): discrimination_vector={anchor.discrimination_vector}")

--- a/py_irt/initializers.py
+++ b/py_irt/initializers.py
@@ -157,16 +157,23 @@ class AnchorItemInitializer(IrtInitializer):
                 # console.log(f"  {item_id} (ix={item_ix}): difficulty_vector={anchor.difficulty_vector}")
             
             # Set discrimination (vector for multidim, scalar for 1D)
-            # Discrimination params are in log-space (LogNormal guide), so store log(value)
+            # Discrimination params have constraint=positive, so we must set
+            # unconstrained values (log-space) via the param store directly.
             if has_disc:
                 disc_value = anchor.discrimination_vector if is_multidim else anchor.discrimination
                 if disc_value is not None:
                     with torch.no_grad():
                         if isinstance(disc_value, list):
                             disc_value = torch.tensor(disc_value, dtype=loc_disc.dtype, device=loc_disc.device)
-                            disc_value = torch.log(disc_value)
                         else:
-                            disc_value = torch.log(torch.tensor(float(disc_value), dtype=loc_disc.dtype, device=loc_disc.device))
-                        loc_disc[item_ix] = disc_value
-                        scale_disc[item_ix] = NEAR_ZERO_SCALE
+                            disc_value = torch.tensor(float(disc_value), dtype=loc_disc.dtype, device=loc_disc.device)
+                        param_store = pyro.get_param_store()
+                        disc_name = "loc_slope" if "loc_slope" in param_store else "loc_disc"
+                        scale_name = "scale_slope" if "scale_slope" in param_store else "scale_disc"
+                        # Set unconstrained loc to log(target) so constrained = exp(log(target)) = target
+                        param_store._params[disc_name].data[item_ix] = disc_value.log()
+                        # Set unconstrained scale to log(NEAR_ZERO_SCALE) for a near-delta distribution
+                        param_store._params[scale_name].data[item_ix] = torch.tensor(
+                            NEAR_ZERO_SCALE, dtype=loc_disc.dtype, device=loc_disc.device
+                        ).log()
                     # console.log(f"  {item_id} (ix={item_ix}): discrimination_vector={anchor.discrimination_vector}")

--- a/py_irt/models/four_param_logistic.py
+++ b/py_irt/models/four_param_logistic.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
@@ -188,7 +188,11 @@ class FourParamLog(abstract_model.IrtModel):
             torch.ones(self.num_items, device=self.device),
             constraint=constraints.positive,
         )
-        m_gamma_param = pyro.param("loc_disc", torch.zeros(self.num_items, device=self.device))
+        m_gamma_param = pyro.param(
+            "loc_disc",
+            torch.ones(self.num_items, device=self.device),
+            constraint=constraints.positive,
+        )
         s_gamma_param = pyro.param(
             "scale_disc",
             torch.ones(self.num_items, device=self.device),
@@ -212,14 +216,13 @@ class FourParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
-            "disc": pyro.param("loc_disc").data.exp().tolist(),
+            "disc": pyro.param("loc_disc").data.tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/four_param_logistic.py
+++ b/py_irt/models/four_param_logistic.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-5, 5), (1.0 / u_gamma).clamp(max=2.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
@@ -190,8 +190,7 @@ class FourParamLog(abstract_model.IrtModel):
         )
         m_gamma_param = pyro.param(
             "loc_disc",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -216,13 +215,13 @@ class FourParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/four_param_logistic.py
+++ b/py_irt/models/four_param_logistic.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
@@ -212,13 +212,14 @@ class FourParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.Normal(m_gamma_param, s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/four_param_logistic.py
+++ b/py_irt/models/four_param_logistic.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))

--- a/py_irt/models/multidim_2pl.py
+++ b/py_irt/models/multidim_2pl.py
@@ -53,7 +53,8 @@ class Multidim2PL(IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
         }
 
     def get_model(self):
@@ -127,7 +128,7 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1):
-                disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+                disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             multidim_logits = disc[items] * (ability[subjects] - diff[items])
@@ -249,4 +250,4 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1, device=self.device):
-                gamma = pyro.sample("gamma", dist.Normal(m_gamma_param, s_gamma_param))
+                gamma = pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))

--- a/py_irt/models/multidim_2pl.py
+++ b/py_irt/models/multidim_2pl.py
@@ -53,8 +53,7 @@ class Multidim2PL(IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
-            "disc": pyro.param("loc_disc").data.exp().tolist(),
+            "disc": pyro.param("loc_disc").data.tolist(),
         }
 
     def get_model(self):
@@ -128,7 +127,7 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1):
-                disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+                disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             multidim_logits = disc[items] * (ability[subjects] - diff[items])
@@ -210,7 +209,9 @@ class Multidim2PL(IrtModel):
         )
 
         m_gamma_param = pyro.param(
-            "loc_disc", torch.zeros([self.num_items, self.dims], device=self.device)
+            "loc_disc",
+            torch.ones([self.num_items, self.dims], device=self.device),
+            constraint=constraints.positive,
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -250,4 +251,4 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1, device=self.device):
-                gamma = pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
+                gamma = pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))

--- a/py_irt/models/multidim_2pl.py
+++ b/py_irt/models/multidim_2pl.py
@@ -53,7 +53,7 @@ class Multidim2PL(IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
         }
 
     def get_model(self):
@@ -127,7 +127,7 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1):
-                disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
+                disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-5, 5), (1.0 / u_gamma).clamp(max=2.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             multidim_logits = disc[items] * (ability[subjects] - diff[items])
@@ -210,8 +210,7 @@ class Multidim2PL(IrtModel):
 
         m_gamma_param = pyro.param(
             "loc_disc",
-            torch.ones([self.num_items, self.dims], device=self.device),
-            constraint=constraints.positive,
+            torch.zeros([self.num_items, self.dims], device=self.device),
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -251,4 +250,4 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1, device=self.device):
-                gamma = pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
+                gamma = pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))

--- a/py_irt/models/multidim_2pl.py
+++ b/py_irt/models/multidim_2pl.py
@@ -128,7 +128,7 @@ class Multidim2PL(IrtModel):
 
         with pyro.plate("gammas", self.num_items, dim=-2, device=self.device):
             with pyro.plate("gamma_dims", self.dims, dim=-1):
-                disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
+                disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             multidim_logits = disc[items] * (ability[subjects] - diff[items])

--- a/py_irt/models/three_param_logistic.py
+++ b/py_irt/models/three_param_logistic.py
@@ -118,7 +118,7 @@ class ThreeParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-5, 5), (1.0 / u_gamma).clamp(max=2.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(
@@ -199,8 +199,7 @@ class ThreeParamLog(abstract_model.IrtModel):
         )
         m_gamma_param = pyro.param(
             "loc_disc",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -230,13 +229,13 @@ class ThreeParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/three_param_logistic.py
+++ b/py_irt/models/three_param_logistic.py
@@ -118,7 +118,7 @@ class ThreeParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(
@@ -197,8 +197,11 @@ class ThreeParamLog(abstract_model.IrtModel):
             torch.ones(self.num_items, device=self.device),
             constraint=constraints.positive,
         )
-        m_gamma_param = pyro.param("loc_disc", torch.zeros(
-            self.num_items, device=self.device))
+        m_gamma_param = pyro.param(
+            "loc_disc",
+            torch.ones(self.num_items, device=self.device),
+            constraint=constraints.positive,
+        )
         s_gamma_param = pyro.param(
             "scale_disc",
             torch.ones(self.num_items, device=self.device),
@@ -227,14 +230,13 @@ class ThreeParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
-            "disc": pyro.param("loc_disc").data.exp().tolist(),
+            "disc": pyro.param("loc_disc").data.tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/three_param_logistic.py
+++ b/py_irt/models/three_param_logistic.py
@@ -118,7 +118,7 @@ class ThreeParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(
@@ -227,13 +227,14 @@ class ThreeParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.Normal(m_gamma_param, s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
             "lambdas": pyro.param("lambdas").data.tolist(),
         }
 

--- a/py_irt/models/three_param_logistic.py
+++ b/py_irt/models/three_param_logistic.py
@@ -118,7 +118,7 @@ class ThreeParamLog(abstract_model.IrtModel):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(

--- a/py_irt/models/tutorial_model.py
+++ b/py_irt/models/tutorial_model.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             # We want to make disc non-negative, which we can implement by changing from:
             # disc ~ Normal
             # To:
-            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
@@ -195,7 +195,9 @@ class FourParamLog(abstract_model.IrtModel):
             constraint=constraints.positive,
         )
         m_gamma_param = pyro.param(
-            "loc_disc", torch.zeros(self.num_items, device=self.device)
+            "loc_disc",
+            torch.ones(self.num_items, device=self.device),
+            constraint=constraints.positive,
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -228,14 +230,13 @@ class FourParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
-            "disc": pyro.param("loc_disc").data.exp().tolist(),
+            "disc": pyro.param("loc_disc").data.tolist(),
         }
 
     def predict(self, subjects, items, params_from_file=None):

--- a/py_irt/models/tutorial_model.py
+++ b/py_irt/models/tutorial_model.py
@@ -115,11 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             # We want to make disc non-negative, which we can implement by changing from:
             # disc ~ Normal
             # To:
-            # log disc ~ Normal
-            # Re-arranging:
-            # disc ~ exp(Normal)
-            # Or just draw from LogNormal
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma, 1.0 / u_gamma))
+            disc = pyro.sample("gamma", dist.Normal(mu_gamma, 1.0 / u_gamma))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))

--- a/py_irt/models/tutorial_model.py
+++ b/py_irt/models/tutorial_model.py
@@ -115,7 +115,7 @@ class FourParamLog(abstract_model.IrtModel):
             # We want to make disc non-negative, which we can implement by changing from:
             # disc ~ Normal
             # To:
-            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-10, 10), (1.0 / u_gamma).clamp(max=3.0)))
+            disc = pyro.sample("gamma", dist.LogNormal(mu_gamma.clamp(-5, 5), (1.0 / u_gamma).clamp(max=2.0)))
 
         with pyro.plate("observe_data", obs.size(0)):
             p_star = torch.sigmoid(disc[items] * (ability[subjects] - diff[items]))
@@ -196,8 +196,7 @@ class FourParamLog(abstract_model.IrtModel):
         )
         m_gamma_param = pyro.param(
             "loc_disc",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_gamma_param = pyro.param(
             "scale_disc",
@@ -230,13 +229,13 @@ class FourParamLog(abstract_model.IrtModel):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
 
         with pyro.plate("gammas", self.num_items, device=self.device):
-            pyro.sample("gamma", dist.LogNormal(m_gamma_param.log(), s_gamma_param))
+            pyro.sample("gamma", dist.LogNormal(m_gamma_param, s_gamma_param))
 
     def export(self):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
         }
 
     def predict(self, subjects, items, params_from_file=None):

--- a/py_irt/models/tutorial_model.py
+++ b/py_irt/models/tutorial_model.py
@@ -238,7 +238,8 @@ class FourParamLog(abstract_model.IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_disc").data.tolist(),
+            # loc_disc is the LogNormal location (log-space); exp() gives the median discrimination
+            "disc": pyro.param("loc_disc").data.exp().tolist(),
         }
 
     def predict(self, subjects, items, params_from_file=None):

--- a/py_irt/models/two_param_logistic.py
+++ b/py_irt/models/two_param_logistic.py
@@ -173,7 +173,7 @@ class TwoParamLog(abstract_model.IrtModel):
             ability = pyro.sample("theta", dist.Normal(mu_theta, 1.0 / u_theta))
         with pyro.plate("bs", self.num_items, device=self.device):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
-            slope = pyro.sample("a", dist.LogNormal(mu_a, 1.0 / u_a))
+            slope = pyro.sample("a", dist.Normal(mu_a, 1.0 / u_a))
         with pyro.plate("observe_data", obs.size(0)):
             pyro.sample(
                 "obs",

--- a/py_irt/models/two_param_logistic.py
+++ b/py_irt/models/two_param_logistic.py
@@ -112,7 +112,8 @@ class TwoParamLog(abstract_model.IrtModel):
         )
         m_a_param = pyro.param(
             "loc_slope",
-            torch.zeros(self.num_items, device=self.device),
+            torch.ones(self.num_items, device=self.device),
+            constraint=constraints.positive,
         )
         s_a_param = pyro.param(
             "scale_slope",
@@ -128,7 +129,7 @@ class TwoParamLog(abstract_model.IrtModel):
             dist_b = dist.Normal(m_b_param, s_b_param)
             pyro.sample("b", dist_b)
 
-            dist_a = dist.LogNormal(m_a_param, s_a_param)
+            dist_a = dist.LogNormal(m_a_param.log(), s_a_param)
             pyro.sample("a", dist_a)
 
     def model_hierarchical(self, subjects, items, obs):
@@ -173,7 +174,7 @@ class TwoParamLog(abstract_model.IrtModel):
             ability = pyro.sample("theta", dist.Normal(mu_theta, 1.0 / u_theta))
         with pyro.plate("bs", self.num_items, device=self.device):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
-            slope = pyro.sample("a", dist.Normal(mu_a, 1.0 / u_a))
+            slope = pyro.sample("a", dist.LogNormal(mu_a.clamp(-10, 10), (1.0 / u_a).clamp(max=3.0)))
         with pyro.plate("observe_data", obs.size(0)):
             pyro.sample(
                 "obs",
@@ -229,7 +230,11 @@ class TwoParamLog(abstract_model.IrtModel):
             torch.ones(self.num_items, device=self.device),
             constraint=constraints.positive,
         )
-        m_a_param = pyro.param("loc_slope", torch.zeros(self.num_items, device=self.device))
+        m_a_param = pyro.param(
+            "loc_slope",
+            torch.ones(self.num_items, device=self.device),
+            constraint=constraints.positive,
+        )
         s_a_param = pyro.param(
             "scale_slope",
             torch.ones(self.num_items, device=self.device),
@@ -248,7 +253,7 @@ class TwoParamLog(abstract_model.IrtModel):
             pyro.sample("theta", dist.Normal(m_theta_param, s_theta_param))
         with pyro.plate("bs", self.num_items, device=self.device):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
-            pyro.sample("a", dist.LogNormal(m_a_param, s_a_param))
+            pyro.sample("a", dist.LogNormal(m_a_param.log(), s_a_param))
 
     def get_model(self):
         if self.priors == "vague":
@@ -266,8 +271,7 @@ class TwoParamLog(abstract_model.IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_slope is the LogNormal location (log-space); exp() gives the median discrimination
-            "disc": pyro.param("loc_slope").data.exp().tolist(),
+            "disc": pyro.param("loc_slope").data.tolist(),
         }
 
     def fit_MCMC(self, models, items, responses, num_epochs):

--- a/py_irt/models/two_param_logistic.py
+++ b/py_irt/models/two_param_logistic.py
@@ -112,8 +112,7 @@ class TwoParamLog(abstract_model.IrtModel):
         )
         m_a_param = pyro.param(
             "loc_slope",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_a_param = pyro.param(
             "scale_slope",
@@ -129,7 +128,7 @@ class TwoParamLog(abstract_model.IrtModel):
             dist_b = dist.Normal(m_b_param, s_b_param)
             pyro.sample("b", dist_b)
 
-            dist_a = dist.LogNormal(m_a_param.log(), s_a_param)
+            dist_a = dist.LogNormal(m_a_param, s_a_param)
             pyro.sample("a", dist_a)
 
     def model_hierarchical(self, subjects, items, obs):
@@ -174,7 +173,7 @@ class TwoParamLog(abstract_model.IrtModel):
             ability = pyro.sample("theta", dist.Normal(mu_theta, 1.0 / u_theta))
         with pyro.plate("bs", self.num_items, device=self.device):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
-            slope = pyro.sample("a", dist.LogNormal(mu_a.clamp(-10, 10), (1.0 / u_a).clamp(max=3.0)))
+            slope = pyro.sample("a", dist.LogNormal(mu_a.clamp(-5, 5), (1.0 / u_a).clamp(max=2.0)))
         with pyro.plate("observe_data", obs.size(0)):
             pyro.sample(
                 "obs",
@@ -232,8 +231,7 @@ class TwoParamLog(abstract_model.IrtModel):
         )
         m_a_param = pyro.param(
             "loc_slope",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_a_param = pyro.param(
             "scale_slope",
@@ -253,7 +251,7 @@ class TwoParamLog(abstract_model.IrtModel):
             pyro.sample("theta", dist.Normal(m_theta_param, s_theta_param))
         with pyro.plate("bs", self.num_items, device=self.device):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
-            pyro.sample("a", dist.LogNormal(m_a_param.log(), s_a_param))
+            pyro.sample("a", dist.LogNormal(m_a_param, s_a_param))
 
     def get_model(self):
         if self.priors == "vague":
@@ -271,7 +269,7 @@ class TwoParamLog(abstract_model.IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_slope").data.tolist(),
+            "disc": pyro.param("loc_slope").data.exp().tolist(),
         }
 
     def fit_MCMC(self, models, items, responses, num_epochs):

--- a/py_irt/models/two_param_logistic.py
+++ b/py_irt/models/two_param_logistic.py
@@ -112,8 +112,7 @@ class TwoParamLog(abstract_model.IrtModel):
         )
         m_a_param = pyro.param(
             "loc_slope",
-            torch.ones(self.num_items, device=self.device),
-            constraint=constraints.positive,
+            torch.zeros(self.num_items, device=self.device),
         )
         s_a_param = pyro.param(
             "scale_slope",
@@ -267,7 +266,7 @@ class TwoParamLog(abstract_model.IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            # loc_slope is in log-space (LogNormal guide), exponentiate to get discrimination
+            # loc_slope is the LogNormal location (log-space); exp() gives the median discrimination
             "disc": pyro.param("loc_slope").data.exp().tolist(),
         }
 

--- a/py_irt/models/two_param_logistic.py
+++ b/py_irt/models/two_param_logistic.py
@@ -81,7 +81,7 @@ class TwoParamLog(abstract_model.IrtModel):
             )
             slope = pyro.sample(
                 "a",
-                dist.Normal(
+                dist.LogNormal(
                     torch.tensor(0.0, device=self.device), torch.tensor(0.1, device=self.device)
                 ),
             )
@@ -129,7 +129,7 @@ class TwoParamLog(abstract_model.IrtModel):
             dist_b = dist.Normal(m_b_param, s_b_param)
             pyro.sample("b", dist_b)
 
-            dist_a = dist.Normal(m_a_param, s_a_param)
+            dist_a = dist.LogNormal(m_a_param, s_a_param)
             pyro.sample("a", dist_a)
 
     def model_hierarchical(self, subjects, items, obs):
@@ -174,7 +174,7 @@ class TwoParamLog(abstract_model.IrtModel):
             ability = pyro.sample("theta", dist.Normal(mu_theta, 1.0 / u_theta))
         with pyro.plate("bs", self.num_items, device=self.device):
             diff = pyro.sample("b", dist.Normal(mu_b, 1.0 / u_b))
-            slope = pyro.sample("a", dist.Normal(mu_a, 1.0 / u_a))
+            slope = pyro.sample("a", dist.LogNormal(mu_a, 1.0 / u_a))
         with pyro.plate("observe_data", obs.size(0)):
             pyro.sample(
                 "obs",
@@ -249,7 +249,7 @@ class TwoParamLog(abstract_model.IrtModel):
             pyro.sample("theta", dist.Normal(m_theta_param, s_theta_param))
         with pyro.plate("bs", self.num_items, device=self.device):
             pyro.sample("b", dist.Normal(m_b_param, s_b_param))
-            pyro.sample("a", dist.Normal(m_a_param, s_a_param))
+            pyro.sample("a", dist.LogNormal(m_a_param, s_a_param))
 
     def get_model(self):
         if self.priors == "vague":
@@ -267,7 +267,8 @@ class TwoParamLog(abstract_model.IrtModel):
         return {
             "ability": pyro.param("loc_ability").data.tolist(),
             "diff": pyro.param("loc_diff").data.tolist(),
-            "disc": pyro.param("loc_slope").data.tolist(),
+            # loc_slope is in log-space (LogNormal guide), exponentiate to get discrimination
+            "disc": pyro.param("loc_slope").data.exp().tolist(),
         }
 
     def fit_MCMC(self, models, items, responses, num_epochs):


### PR DESCRIPTION
## Summary

- All IRT models (2PL, 3PL, 4PL, multidim_2pl) use `dist.Normal` for the discrimination parameter, allowing negative values. In IRT, discrimination must be positive (`a > 0`) — higher ability should always increase P(correct).
- Negative discrimination causes inverted ability scales (cf. #25), pathological item parameters, and inconsistent results across runs.
- **Fix**: Change `dist.Normal` → `dist.LogNormal` for discrimination in all model priors and variational guides. Update `export()` to exponentiate the log-space location parameter to return the median discrimination.

`LogNormal` is the standard choice for discrimination in Bayesian IRT. This is the same fix independently applied by the [Fluid Benchmarking](https://github.com/allenai/fluid-benchmarking/blob/main/irt/two_param_logistic.py) team (Allen AI) in their fork of py-irt.

## Models changed

### 2PL (`two_param_logistic.py`)
- `model_vague`: `dist.Normal` → `dist.LogNormal` for `a`
- `guide_vague`: `dist.Normal` → `dist.LogNormal` for `a`; removed `constraint=constraints.positive` from `loc_slope` (was causing double-exponentiation); init changed from `ones` to `zeros` (log-space: `exp(0)=1`)
- `model_hierarchical`: `dist.Normal` → `dist.LogNormal` for `a`
- `guide_hierarchical`: `dist.Normal` → `dist.LogNormal` for `a`
- `export()`: `loc_slope` → `loc_slope.exp()` (log-space → median discrimination)

### 3PL (`three_param_logistic.py`)
- `model_hierarchical`: `dist.Normal` → `dist.LogNormal` for `gamma`
- `guide_hierarchical`: `dist.Normal` → `dist.LogNormal` for `gamma`
- `export()`: `loc_disc` → `loc_disc.exp()`

### 4PL (`four_param_logistic.py`)
- Same changes as 3PL

### multidim_2pl (`multidim_2pl.py`)
- `model_hierarchical`: `dist.Normal` → `dist.LogNormal` for `gamma`
- `guide_hierarchical`: `dist.Normal` → `dist.LogNormal` for `gamma`
- `export()`: `loc_disc` → `loc_disc.exp()`

### tutorial_model (`tutorial_model.py`)
- `export()`: `loc_disc` → `loc_disc.exp()` (model/guide already used LogNormal)

### Anchor initializer (`initializers.py`)
- `AnchorItemInitializer`: stores `log(disc_value)` since discrimination params are now in log-space

## Impact

We discovered this while using py-irt on SWE-bench data (134 models × 325 items). With `dist.Normal`:
- ~40 items got negative discrimination, creating pathological three-cluster artifact in parameter space
- ELBO loss: ~16,300

After fixing to `dist.LogNormal`:
- All discriminations positive (0.34–3.09)
- ELBO loss: ~14,300 (better fit)
- Observed vs predicted solve rates: r=0.999

## Test plan

- [x] All 37 existing tests pass
- [x] Anchor items test passes (discrimination stays at target value)
- [x] Fit 2PL on a dataset and confirm all discrimination values are positive
- [x] Compare ELBO loss before/after (improves)